### PR TITLE
add missing type header file

### DIFF
--- a/external/inc/crc32c.h
+++ b/external/inc/crc32c.h
@@ -1,6 +1,6 @@
 #ifndef __CRC32C_H
     #define __CRC32C_H
-
+#include <stdint.h>
 uint32_t calc_crc32c (char *data, ssize_t len);
 
 #endif


### PR DESCRIPTION
this fix the "unknown type name 'uint32_t' " when compiling